### PR TITLE
Set trailingSlash: false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,7 @@ const config = {
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.svg",
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -187,6 +188,7 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },
+      metadata: [{name: 'keywords', content: 'cooking, blog'}],
     }),
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.svg",
-  trailingSlash: true,
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,7 +188,6 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },
-      metadata: [{name: 'keywords', content: 'cooking, blog'}],
     }),
 };
 


### PR DESCRIPTION
Set "trailingSlash: false" in global Docusaurus config for consistency between sitemap.xml paths to site paths.