### PR TITLE
changed "kafka-keystore.jks" to "kafka.keystore.jks" because bitnami changed their default

### DIFF
--- a/docs/guides/ibac-for-k8s-kafka/README.mdx
+++ b/docs/guides/ibac-for-k8s-kafka/README.mdx
@@ -81,7 +81,7 @@ Kafka [chart](https://github.com/bitnami/charts/tree/master/bitnami/kafka):
      spire-integration.otterize.com/cert-type: jks
      spire-integration.otterize.com/tls-secret-name: kafka-tls-secret
      spire-integration.otterize.com/truststore-file-name: kafka.truststore.jks
-     spire-integration.otterize.com/keystore-file-name: kafka-keystore.jks
+     spire-integration.otterize.com/keystore-file-name: kafka.keystore.jks
      spire-integration.otterize.com/dns-names: "kafka-0.kafka-headless.kafka.svc.cluster.local,kafka.kafka.svc.cluster.local"
      spire-integration.otterize.com/cert-ttl: "31536000" # 1 year
    ```
@@ -101,7 +101,6 @@ with permissions for Otterize to configure ACLs:
  helm repo add bitnami https://charts.bitnami.com/bitnami
  helm repo update
  helm install -n kafka \
- --version 14.x.x \
  -f https://docs.otterize.com/code-examples/kafka-mtls/helm/values.yaml --create-namespace kafka bitnami/kafka
  ```
 You can watch for all pods to be `Ready` using `kubectl get pods -n kafka -w`.

--- a/docs/guides/ibac-for-k8s-kafka/credentials-for-kafka.mdx
+++ b/docs/guides/ibac-for-k8s-kafka/credentials-for-kafka.mdx
@@ -15,11 +15,11 @@ The examples here reference the Kafka broker and client deployed in the
 
 1. Retrieve the keystore with:
     ```bash
-    kubectl get secret -n kafka kafka-tls-secret -o jsonpath='{.data.kafka-keystore\.jks}' | base64 -d > kafka-keystore.jks
+    kubectl get secret -n kafka kafka-tls-secret -o jsonpath='{.data.kafka\.keystore\.jks}' | base64 -d > kafka.keystore.jks
     ```
 2. Extract the certificate from the store:
     ```bash
-    keytool -storepass password -keystore kafka-keystore.jks -alias pkey -exportcert -rfc > server.pem
+    keytool -storepass password -keystore kafka.keystore.jks -alias pkey -exportcert -rfc > server.pem
     ```
 3. Inspect it with:
     ```bash

--- a/docs/quick-tutorials/k8s-kafka-mtls.mdx
+++ b/docs/quick-tutorials/k8s-kafka-mtls.mdx
@@ -45,7 +45,6 @@ The following command will deploy a Kafka cluster with this chart:
  helm repo add bitnami https://charts.bitnami.com/bitnami
  helm repo update
  helm install --create-namespace -n kafka \
-   --version 14.x.x \
    -f https://docs.otterize.com/code-examples/kafka-mtls/helm/values.yaml kafka bitnami/kafka
  ```
 

--- a/static/code-examples/kafka-mtls/helm/values.yaml
+++ b/static/code-examples/kafka-mtls/helm/values.yaml
@@ -13,7 +13,7 @@ podAnnotations:
   spire-integration.otterize.com/cert-type: jks
   spire-integration.otterize.com/tls-secret-name: kafka-tls-secret
   spire-integration.otterize.com/truststore-file-name: kafka.truststore.jks
-  spire-integration.otterize.com/keystore-file-name: kafka-keystore.jks
+  spire-integration.otterize.com/keystore-file-name: kafka.keystore.jks
   spire-integration.otterize.com/dns-names: "kafka-0.kafka-headless.kafka.svc.cluster.local,kafka.kafka.svc.cluster.local"
 # Authenticate clients using mTLS
 auth:


### PR DESCRIPTION
Also, removed reference to version 14.x.x because bitnami don't keep old versions
Co-written with @omris94