### PR TITLE
improve network policy quickstart guide

### DIFF
--- a/docs/_common/cluster-setup.md
+++ b/docs/_common/cluster-setup.md
@@ -13,7 +13,7 @@ Install Calico:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml
 ```
-You need to install Calico because Minikube does not support network policy enforcement by default, Calico helps solve this issue.
+You need to install Calico because Minikube does not support network policy enforcement by default; Calico helps solve this issue.
 
 </TabItem>
 <TabItem value="gke" label="Google GKE">

--- a/docs/_common/cluster-setup.md
+++ b/docs/_common/cluster-setup.md
@@ -13,13 +13,15 @@ Install Calico:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml
 ```
+You need to install Calico because Minikube does not support network policy enforcement by default, Calico helps solve this issue.
+
 </TabItem>
 <TabItem value="gke" label="Google GKE">
 <a href="https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#gcloud">Visit the official documentation</a>, or follow the instructions below:
 <Tabs>
 <TabItem value="cli" label="gcloud CLI">
 
-To use the gcloud CLI for this tutorial, [install](https://cloud.google.com/sdk/docs/install) and then 
+To use the gcloud CLI for this tutorial, [install](https://cloud.google.com/sdk/docs/install) and then
 [initialize](https://cloud.google.com/sdk/docs/initializing) it.
 
 ***To enable network policy enforcement when creating a new cluster, run the following command:***
@@ -36,7 +38,7 @@ Run the following command to enable the add-on:
 `gcloud container clusters update CLUSTER_NAME --update-addons=NetworkPolicy=ENABLED`
 Replace CLUSTER_NAME with the name of the cluster.
 
-Run the following command to enable network policy enforcement on your cluster, which in turn re-creates your cluster's node pools with network policy enforcement enabled:
+Run the following command to enable network policy enforcement in your cluster, which in turn re-creates your cluster's node pools with network policy enforcement enabled:
 
 `gcloud container clusters update CLUSTER_NAME --enable-network-policy`
 </TabItem>

--- a/docs/_common/install-otterize.md
+++ b/docs/_common/install-otterize.md
@@ -1,4 +1,4 @@
-   Make sure you have [Helm](https://helm.sh/docs/intro/install/) installed on your machine before attempting to install Otterize.
+   You'll need [Helm](https://helm.sh/docs/intro/install/) installed on your machine to install Otterize as follows:
 
    ```shell
    helm repo add otterize https://helm.otterize.com
@@ -10,7 +10,7 @@ This chart is a bundle of the Otterize intents operator, Otterize credentials op
 Initial deployment may take a couple of minutes.
 You can add the `--wait` flag for Helm to wait for deployment to complete and all pods to be Ready, or manually watch for all pods to be `Ready` using `kubectl get pods -n otterize-system -w`.
 
-After all the pods are ready you should see the something similar to the following displayed in your terminal when you manually get all the pods in the Otterize namespace using `kubectl get pods -n otterize-system`.
+After all the pods are ready you should see the following (or similar) in your terminal when you run `kubectl get pods -n otterize-system`:
 
 ``` bash
 NAME                                                       READY  STATUS  RESTARTS AGE

--- a/docs/_common/install-otterize.md
+++ b/docs/_common/install-otterize.md
@@ -1,8 +1,24 @@
+   Make sure you have [Helm](https://helm.sh/docs/intro/install/) installed on your machine before installing Otterize.
+
    ```shell
    helm repo add otterize https://helm.otterize.com
    helm repo update
    helm install otterize otterize/otterize-kubernetes -n otterize-system --create-namespace
    ```
+
 This chart is a bundle of the Otterize intents operator, Otterize credentials operator, Otterize network mapper, and SPIRE.
 Initial deployment may take a couple of minutes.
 You can add the `--wait` flag for Helm to wait for deployment to complete and all pods to be Ready, or manually watch for all pods to be `Ready` using `kubectl get pods -n otterize-system -w`.
+
+After all the pods are ready you should see the something similar to the following displayed in your terminal when you manually get all the pods in the Otterize namespace using `kubectl get pods -n otterize-system`.
+
+``` bash
+NAME                                                       READY  STATUS  RESTARTS AGE
+credentials-operator-controller-manager-6c56fcfcfb-vg6m9   2/2    Running   0     9s
+intents-operator-controller-manager-65bb6d4b88-bp9pf       2/2    Running   0     9s
+otterize-network-mapper-779fffd959-twjqd                   1/1    Running   0     9s
+otterize-network-sniffer-65mjt                             1/1    Running   0     9s
+otterize-spire-agent-lcbq2                                 1/1    Running   0     9s
+otterize-spire-server-0                                    2/2    Running   0     9s
+otterize-watcher-b9bf87bcd-276nt                           1/1    Running   0     9s
+```

--- a/docs/_common/install-otterize.md
+++ b/docs/_common/install-otterize.md
@@ -1,4 +1,4 @@
-   Make sure you have [Helm](https://helm.sh/docs/intro/install/) installed on your machine before installing Otterize.
+   Make sure you have [Helm](https://helm.sh/docs/intro/install/) installed on your machine before attempting to install Otterize.
 
    ```shell
    helm repo add otterize https://helm.otterize.com

--- a/docs/quick-tutorials/k8s-mtls.mdx
+++ b/docs/quick-tutorials/k8s-mtls.mdx
@@ -15,7 +15,7 @@ In this tutorial, we will:
 
 
 <details>
-<summary>Install Otterize on your cluster</summary>
+<summary>Install Otterize in your cluster</summary>
 
 :::note
 You can skip this section if Otterize is already installed in your cluster.

--- a/docs/quick-tutorials/k8s-network-mapper.mdx
+++ b/docs/quick-tutorials/k8s-network-mapper.mdx
@@ -22,7 +22,7 @@ Before you start, you need to have a Kubernetes cluster. Having a cluster with a
 </details>
 
 <details>
-<summary>Install Otterize on your cluster</summary>
+<summary>Install Otterize in your cluster</summary>
 
 :::note
 You can skip this section if Otterize is already installed in your cluster.

--- a/docs/quick-tutorials/k8s-network-policies.mdx
+++ b/docs/quick-tutorials/k8s-network-policies.mdx
@@ -35,6 +35,10 @@ Before you start, you need a Kubernetes cluster with a [CNI](https://kubernetes.
 You can skip this section if Otterize is already installed in your cluster.
 :::
 
+:::note Basic System Memory Requirement
+Otterize requires about 200 MBs and 200 mCPU for all components, including a SPIRE deployment to install and run properly on Minikube and EKS clusters.
+:::
+
 {@include: ../_common/install-otterize.md}
 
 </details>

--- a/docs/quick-tutorials/k8s-network-policies.mdx
+++ b/docs/quick-tutorials/k8s-network-policies.mdx
@@ -35,8 +35,8 @@ Before you start, you need a Kubernetes cluster with a [CNI](https://kubernetes.
 You can skip this section if Otterize is already installed in your cluster.
 :::
 
-:::note Basic System Memory Requirement
-Otterize requires about 200 MBs and 200 mCPU for all components, including a SPIRE deployment to install and run properly on Minikube and EKS clusters.
+:::note Basic system memory requirements
+Otterize requires about 200 MBs and 200 mCPU for all components (including a SPIRE deployment) to install and run properly on Minikube and EKS clusters.
 :::
 
 {@include: ../_common/install-otterize.md}

--- a/docs/quick-tutorials/k8s-network-policies.mdx
+++ b/docs/quick-tutorials/k8s-network-policies.mdx
@@ -29,7 +29,7 @@ Before you start, you need a Kubernetes cluster with a [CNI](https://kubernetes.
 </details>
 
 <details>
-<summary>Install Otterize on your cluster</summary>
+<summary>Install Otterize in your cluster</summary>
 
 :::note
 You can skip this section if Otterize is already installed in your cluster.


### PR DESCRIPTION
Please see the [contributing guidelines](CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. This template is based on Auth0's excellent template.

### Description

In this PR, I made the following changes based on a series of discussions with Ori:

- Grammatical change: I switched the phrase "on your cluster" to "in your cluster" wherever it appears in the docs because it's supposed to be in since otterize is installed as a part of the Kubernetes cluster. 

- Added a line about installing helm in your machine, just in case a user doesn't have one before trying to install Otterize.

- Added a line about why Calico needs to be installed so that readers can understand why it is necessary for Minikube users

- Added instructions on how to view otterize pods that are running correctly after installing Otterize onto your Minikube cluster. It's essential for readers to know what a healthy installation looks like

- Added a note on the basic system requirement for installing Otterize on Minikube and EKS.
