### PR TITLE
Fix legacy service name annotation

### DIFF
--- a/docs/reference/service-identities/README.mdx
+++ b/docs/reference/service-identities/README.mdx
@@ -8,9 +8,9 @@ Otterize uses universal service identities to refer to services, regardless of w
 ## Kubernetes service identity resolution
 How do Otterize operators decide what is the name of the service that runs within the pod? The algorithm is as follows:
 
-1. If the pod has an `otterize/service-name` label, its value is used as the service name. This allows developers and
+1. If the pod has an `intents.otterize.com/service-name` label, its value is used as the service name. This allows developers and
    automations to explicitly name services, if needed.
-2. If there is no `otterize/service-name` label, a recursive look up is performed for the Kubernetes resource owner of
+2. If there is no `intents.otterize.com/service-name` label, a recursive look up is performed for the Kubernetes resource owner of
    the pod, until the root resource is reached, and its name is used as the service name. For example, if you have
    a `Deployment` named `checkoutservice`, which then creates and owns a `ReplicaSet`, which then creates and owns
    a `Pod`, then the service name for that pod is `checkoutservice` - same as the name of the `Deployment`. This is


### PR DESCRIPTION
The "Kubernetes service identity resolution" section contained outdated information about our service name annotation. This PR update with an updated label name.