### PR TITLE
For wildcard topics, pattern type should be literal (in KafkaServerConfig)

### DIFF
--- a/docs/quick-tutorials/k8s-kafka-mtls.mdx
+++ b/docs/quick-tutorials/k8s-kafka-mtls.mdx
@@ -108,7 +108,7 @@ kubectl logs -n kafka statefulset/kafka | grep "Processing Acl change" | grep AN
 You should see the following output:
 ```
 [2022-09-13 10:58:32,052] INFO Processing Acl change notification for
-ResourcePattern(resourceType=TOPIC, name=*, patternType=PREFIXED), versionedAcls :
+ResourcePattern(resourceType=TOPIC, name=*, patternType=LITERAL), versionedAcls :
 Set(User:ANONYMOUS has ALLOW permission for operations: ALL from hosts: *,
 User:* has ALLOW permission for operations: ALL from hosts: *), zkVersion : 0
 (kafka.security.authorizer.AclAuthorizer)

--- a/docs/reference/configuration/intents-operator/configuration.mdx
+++ b/docs/reference/configuration/intents-operator/configuration.mdx
@@ -27,7 +27,7 @@ spec:
     rootCAFile: /etc/otterize-spire/bundle.pem
   topics: # configuration for topic scope - how ACLs should be applied to each topic or set of topics.
     - topic: "*" # A specific topic or a prefix. Can be "*" for all.
-      pattern: prefix # Prefix or literal. Use prefix for "*".
+      pattern: literal # Prefix or literal. Use literal for "*".
       clientIdentityRequired: false # Whether client identity is required. If set to true to, access by anonymous users will be denied.
       intentsRequired: false # Whether intents are required - if set to true, all access will be denied unless intents are declared
 ```
@@ -82,7 +82,7 @@ Here are example configurations for topic scope and the resulting ACLs.
 #### Allow unauthenticated access to all topics
 ```yaml title="Topic scope"
 - topic: "*"
-  pattern: prefix
+  pattern: literal
   clientIdentityRequired: false
   intentsRequired: false
 ```

--- a/static/code-examples/ibac-for-kafka/kafkaserverconfig-my-topic.yaml
+++ b/static/code-examples/ibac-for-kafka/kafkaserverconfig-my-topic.yaml
@@ -13,7 +13,7 @@ spec:
     rootCAFile: /etc/otterize-spire/ca.pem
   topics:
     - topic: "*"
-      pattern: prefix
+      pattern: literal
       clientIdentityRequired: false
       intentsRequired: false
     - topic: "my-topic"

--- a/static/code-examples/ibac-for-kafka/kafkaserverconfig.yaml
+++ b/static/code-examples/ibac-for-kafka/kafkaserverconfig.yaml
@@ -13,6 +13,6 @@ spec:
     rootCAFile: /etc/otterize-spire/ca.pem
   topics:
     - topic: "*"
-      pattern: prefix
+      pattern: literal
       clientIdentityRequired: false
       intentsRequired: false

--- a/static/code-examples/kafka-mtls/kafkaserverconfig.yaml
+++ b/static/code-examples/kafka-mtls/kafkaserverconfig.yaml
@@ -13,6 +13,6 @@ spec:
     rootCAFile: /etc/otterize-spire/ca.pem
   topics:
     - topic: "*"
-      pattern: prefix
+      pattern: literal
       clientIdentityRequired: false
       intentsRequired: false

--- a/static/code-examples/shadow-mode/kafkaserverconfig.yaml
+++ b/static/code-examples/shadow-mode/kafkaserverconfig.yaml
@@ -13,6 +13,6 @@ spec:
     rootCAFile: /etc/otterize-spire/ca.pem
   topics:
     - topic: "*"
-      pattern: prefix
+      pattern: literal
       clientIdentityRequired: false
       intentsRequired: false


### PR DESCRIPTION
### Description
For wildcard topics, pattern type should be literal (in KafkaServerConfig)

### References
https://docs.confluent.io/platform/current/kafka/authorization.html#prefixed-acls
and also, Kafka AclAuthorizer source code. 