### PR TITLE
Fix Kafka tutorial - change remaining topic names to mytopic

### DIFF
--- a/docs/quick-tutorials/k8s-kafka-mtls.mdx
+++ b/docs/quick-tutorials/k8s-kafka-mtls.mdx
@@ -111,7 +111,7 @@ kubectl apply -f https://docs.otterize.com/code-examples/kafka-mtls/kafkaserverc
 </Tabs>
 </details>
 
-Upon applying the KafkaServerConfig, an ACL will configure Kafka to allow only authenticated access to the *transactions* topic by denying all anonymous access.
+Upon applying the KafkaServerConfig, an ACL will configure Kafka to allow only authenticated access to the *mytopic* topic by denying all anonymous access.
 This will be the base state, from which we will gradually roll out secure access to Kafka.
 
 ```bash
@@ -119,7 +119,7 @@ kubectl logs -n kafka statefulset/kafka | grep "Processing Acl change" | grep AN
 ```
 You should see the following output:
 ```
-[2023-04-12 20:05:32,344] INFO Processing Acl change notification for ResourcePattern(resourceType=TOPIC, name=transactions, patternType=LITERAL), versionedAcls : Set(User:ANONYMOUS has DENY permission for operations: ALL from hosts: *), zkVersion : 0 (kafka.security.authorizer.AclAuthorizer)
+[2023-04-12 20:05:32,344] INFO Processing Acl change notification for ResourcePattern(resourceType=TOPIC, name=mytopic, patternType=LITERAL), versionedAcls : Set(User:ANONYMOUS has DENY permission for operations: ALL from hosts: *), zkVersion : 0 (kafka.security.authorizer.AclAuthorizer)
 ```
 
 ## Deploy clients
@@ -311,7 +311,7 @@ kubectl logs -f --tail 1 -n otterize-tutorial-kafka-mtls deploy/client-authentic
 ```
 Loading mTLS certificates
 Connecting to Kafka
-Creating a producer for - transactions
+Creating a producer for - mytopic
 Sending messages
 Sent message - Message 1 [sent by client-authenticated]
 Sent message - Message 2 [sent by client-authenticated]
@@ -348,7 +348,7 @@ client in namespace otterize-tutorial-kafka-mtls calls:
     - Kafka topic: mytopic, operations: [produce]
 client-authenticated in namespace otterize-tutorial-kafka-mtls calls:
   - kafka in namespace kafka
-    - Kafka topic: transactions, operations: [produce]
+    - Kafka topic: mytopic, operations: [produce]
 client-other in namespace otterize-tutorial-kafka-mtls calls:
   - kafka in namespace kafka
     - Kafka topic: mytopic, operations: [produce]
@@ -416,7 +416,7 @@ kubectl logs -f --tail 1 -n otterize-tutorial-kafka-mtls deploy/client-authentic
 ```
 Loading mTLS certificates
 Connecting to Kafka
-Creating a producer for - transactions
+Creating a producer for - mytopic
 Sending messages
 Sent message - Message 263 [sent by client-authenticated]
 Sent message - Message 264 [sent by client-authenticated]

--- a/static/code-examples/kafka-mtls/all.yaml
+++ b/static/code-examples/kafka-mtls/all.yaml
@@ -430,7 +430,7 @@ data:
     
     const (
         kafkaAddr     = "kafka.kafka:9092"
-        testTopicName = "transactions"
+        testTopicName = "mytopic"
         certFile      = "/var/otterize/credentials/cert.pem"
         keyFile       = "/var/otterize/credentials/key.pem"
         rootCAFile    = "/var/otterize/credentials/ca.pem"

--- a/static/code-examples/kafka-mtls/client-authenticated-configmap.yaml
+++ b/static/code-examples/kafka-mtls/client-authenticated-configmap.yaml
@@ -19,7 +19,7 @@ data:
     
     const (
         kafkaAddr     = "kafka.kafka:9092"
-        testTopicName = "transactions"
+        testTopicName = "mytopic"
         certFile      = "/var/otterize/credentials/cert.pem"
         keyFile       = "/var/otterize/credentials/key.pem"
         rootCAFile    = "/var/otterize/credentials/ca.pem"

--- a/static/code-examples/kafka-mtls/kafkaserverconfig.yaml
+++ b/static/code-examples/kafka-mtls/kafkaserverconfig.yaml
@@ -12,7 +12,7 @@ spec:
     keyFile: /etc/otterize-spire/key.pem
     rootCAFile: /etc/otterize-spire/ca.pem
   topics:
-    - topic: "transactions"
+    - topic: "mytopic"
       pattern: literal
       clientIdentityRequired: true
       intentsRequired: false


### PR DESCRIPTION
### Description

Some parts of the tutorial used the wrong Kafka topic name (probably was changed at some point), which caused the tutorial to not work cleanly. This PR changes all references to the topic name to `mytopic`.
