### PR TITLE
Update the release version of the CLI to v0.1.24

### DIFF
--- a/docs/_common/install-otterize-cli.md
+++ b/docs/_common/install-otterize-cli.md
@@ -13,7 +13,7 @@ brew install otterize/otterize/otterize-cli
 <TabItem value="Apple Silicon" label="Apple Silicon">
 
 ```bash
-curl -LJO https://get.otterize.com/otterize-cli/v0.1.22/otterize_macOS_arm64_notarized.zip
+curl -LJO https://get.otterize.com/otterize-cli/v0.1.24/otterize_macOS_arm64_notarized.zip
 tar xf otterize_macOS_arm64_notarized.zip
 sudo cp otterize /usr/local/bin  # optionally move to PATH
 ```
@@ -21,7 +21,7 @@ sudo cp otterize /usr/local/bin  # optionally move to PATH
 <TabItem value="Intel 64-bit" label="Intel 64-bit">
 
 ```bash
-curl -LJO https://get.otterize.com/otterize-cli/v0.1.22/otterize_macOS_x86_64_notarized.zip
+curl -LJO https://get.otterize.com/otterize-cli/v0.1.24/otterize_macOS_x86_64_notarized.zip
 tar xf otterize_macOS_x86_64_notarized.zip
 sudo cp otterize /usr/local/bin  # optionally move to PATH
 ```
@@ -42,7 +42,7 @@ scoop install otterize-cli
 <TabItem value="64-bit" label="64-bit">
 
 ```PowerShell
-Invoke-WebRequest -Uri https://get.otterize.com/otterize-cli/v0.1.22/otterize_Windows_x86_64.zip -OutFile otterize_Windows_x86_64.zip
+Invoke-WebRequest -Uri https://get.otterize.com/otterize-cli/v0.1.24/otterize_Windows_x86_64.zip -OutFile otterize_Windows_x86_64.zip
 Expand-Archive otterize_Windows_x86_64.zip -DestinationPath .
 # optionally move to PATH
 ```
@@ -54,7 +54,7 @@ Expand-Archive otterize_Windows_x86_64.zip -DestinationPath .
 <TabItem value="64-bit" label="64-bit">
 
 ```bash
-wget https://get.otterize.com/otterize-cli/v0.1.22/otterize_Linux_x86_64.tar.gz
+wget https://get.otterize.com/otterize-cli/v0.1.24/otterize_Linux_x86_64.tar.gz
 tar xf otterize_Linux_x86_64.tar.gz
 sudo cp otterize /usr/local/bin  # optionally move to PATH
 ```


### PR DESCRIPTION

### Description

Update the release version of the CLI to v0.1.24


### References

https://github.com/otterize/otterize-cli/tree/v0.1.24
