### PR TITLE
Increase Kafka service liveness check to 140sec instead of 10sec

### DIFF
--- a/static/code-examples/shadow-mode/ecom-demo-mtls.yaml
+++ b/static/code-examples/shadow-mode/ecom-demo-mtls.yaml
@@ -1601,7 +1601,7 @@ spec:
               containerPort: 9093
           livenessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 10
+            initialDelaySeconds: 140
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5

--- a/static/code-examples/shadow-mode/ecom-demo.yaml
+++ b/static/code-examples/shadow-mode/ecom-demo.yaml
@@ -1531,7 +1531,7 @@ spec:
               containerPort: 9093
           livenessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 10
+            initialDelaySeconds: 140
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
### Description
Sometimes, the Kafka pod gets stuck during creation because the liveness check occurs before the pod is ready. To prevent this from happening, I increased the timeout to 140 seconds, which should mostly eliminate the issue.


