### PR TITLE
Document CLI flags exclude-labels, exclude-services and server.

### DIFF
--- a/docs/reference/cli/README.mdx
+++ b/docs/reference/cli/README.mdx
@@ -147,13 +147,13 @@ as YAML [client intents file(s)](/reference/intents-and-intents-files/#intents-f
 
 | Name                   | Default       | Description                                                                                                                                                                 |
 |------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--format`             | `yaml`        | Specifies the format for the export: "yaml" or "json".                                                                                                                      |
+| `--format`             | `yaml`        | Specifies the format for the export: either `yaml` or `json`.                                                                                                                      |
 | `-n` or `--namespaces` |               | Export only clients in these namespaces (comma-separated).                                                                                                                  |
 | `-o` or `--output`     | `STDOUT`      | Filename or directory for redirecting the output.                                                                                                                           |
 | `--output-type`        | `single-file` | Whether the output should be written as a single file (`single-file`) or as multiple files in a directory (`dir`). Requires the `-o` or `--output` to point to a directory. |
-| `--server `             |               | Export only intents that call this server. Specify the full service name, such as `servername.namespace`                                                                                                                                   |
-| `--exclude-labels`     |               | A list of labels that would exclude services from list/export. example: "include=false"                                                                                     |
-| `--exclude-services`   |               | A list of service to exclude from list/export. example: "service1,service2"                                                                                                 |
+| `--server`             |               | Export only intents for clients that call this server. The server name must be specified with both service name and namespace, in the format `<SERVERNAME>.<SERVER_NAMESPACE>`. Example: `cartservice.otterize-ecom-demo`.                                                       |
+| `--exclude-labels`     |               | A list of labels that would exclude services from list/export. Example: `include=false` would exclude any service labeled with `include=false` from being included in list/export. |
+| `--exclude-services`   |               | A list of services to exclude from list/export. Example: `service1,service2`.                                                                                                |
 
 #### Returns
 

--- a/docs/reference/cli/README.mdx
+++ b/docs/reference/cli/README.mdx
@@ -151,7 +151,7 @@ as YAML [client intents file(s)](/reference/intents-and-intents-files/#intents-f
 | `-n` or `--namespaces` |               | Export only clients in these namespaces (comma-separated).                                                                                                                  |
 | `-o` or `--output`     | `STDOUT`      | Filename or directory for redirecting the output.                                                                                                                           |
 | `--output-type`        | `single-file` | Whether the output should be written as a single file (`single-file`) or as multiple files in a directory (`dir`). Requires the `-o` or `--output` to point to a directory. |
-| `--server              |               | Export only intents that call this server                                                                                                                                   |
+| `--server `             |               | Export only intents that call this server. Specify the full service name, such as `servername.namespace`                                                                                                                                   |
 | `--exclude-labels`     |               | A list of labels that would exclude services from list/export. example: "include=false"                                                                                     |
 | `--exclude-services`   |               | A list of service to exclude from list/export. example: "service1,service2"                                                                                                 |
 

--- a/docs/reference/cli/README.mdx
+++ b/docs/reference/cli/README.mdx
@@ -125,11 +125,13 @@ Uses GraphViz (specifically go-graphviz) to generate the image.
 
 #### Options
 
-| Name                    | Default | Description                                                 |
-|-------------------------|---------|-------------------------------------------------------------|
-| `--format`              | `png`   | Image output format: "png" or "jpg".                        |
-| `-n` or `--namespaces`  |         | Include only clients in these namespaces (comma-separated). |
-| `-o` or `--output-path` |         | Filename for the image.                                     |
+| Name                    | Default | Description                                                                             |
+|-------------------------|---------|-----------------------------------------------------------------------------------------|
+| `--format`              | `png`   | Image output format: "png" or "jpg".                                                    |
+| `-n` or `--namespaces`  |         | Include only clients in these namespaces (comma-separated).                             |
+| `-o` or `--output-path` |         | Filename for the image.                                                                 |
+| `--exclude-labels`      |         | a list of labels that would exclude services from list/export. example: "include=false" |
+| `--exclude-services`    |         | a list of service to exclude from list/export. example: "service1,service2"             |
 
 #### Returns
 
@@ -149,6 +151,9 @@ as YAML [client intents file(s)](/reference/intents-and-intents-files/#intents-f
 | `-n` or `--namespaces` |               | Export only clients in these namespaces (comma-separated).                                                                                                                  |
 | `-o` or `--output`     | `STDOUT`      | Filename or directory for redirecting the output.                                                                                                                           |
 | `--output-type`        | `single-file` | Whether the output should be written as a single file (`single-file`) or as multiple files in a directory (`dir`). Requires the `-o` or `--output` to point to a directory. |
+| `--server              |               | Export only intents that call this server                                                                                                                                   |
+| `--exclude-labels`     |               | a list of labels that would exclude services from list/export. example: "include=false"                                                                                     |
+| `--exclude-services`   |               | a list of service to exclude from list/export. example: "service1,service2"                                                                                                 |
 
 #### Returns
 
@@ -194,10 +199,10 @@ If `--switch-org` is specified, and the current user belongs to multiple org, th
 
 #### Options
 
-| Name | Default | Description |
-| --- | --- | --- |
-| `--switch-account` |  | Login to a different user account than the one currently set. |
-| `--switch-org` |  | Switch to a different organization than the one currently set. |
+| Name               | Default | Description                                                    |
+|--------------------|---------|----------------------------------------------------------------|
+| `--switch-account` |         | Login to a different user account than the one currently set.  |
+| `--switch-org`     |         | Switch to a different organization than the one currently set. |
 
 #### Returns
 

--- a/docs/reference/cli/README.mdx
+++ b/docs/reference/cli/README.mdx
@@ -130,8 +130,8 @@ Uses GraphViz (specifically go-graphviz) to generate the image.
 | `--format`              | `png`   | Image output format: "png" or "jpg".                                                    |
 | `-n` or `--namespaces`  |         | Include only clients in these namespaces (comma-separated).                             |
 | `-o` or `--output-path` |         | Filename for the image.                                                                 |
-| `--exclude-labels`      |         | a list of labels that would exclude services from list/export. example: "include=false" |
-| `--exclude-services`    |         | a list of service to exclude from list/export. example: "service1,service2"             |
+| `--exclude-labels`      |         | A list of labels that would exclude services from list/export. example: "include=false" |
+| `--exclude-services`    |         | A list of service to exclude from list/export. example: "service1,service2"             |
 
 #### Returns
 
@@ -152,8 +152,8 @@ as YAML [client intents file(s)](/reference/intents-and-intents-files/#intents-f
 | `-o` or `--output`     | `STDOUT`      | Filename or directory for redirecting the output.                                                                                                                           |
 | `--output-type`        | `single-file` | Whether the output should be written as a single file (`single-file`) or as multiple files in a directory (`dir`). Requires the `-o` or `--output` to point to a directory. |
 | `--server              |               | Export only intents that call this server                                                                                                                                   |
-| `--exclude-labels`     |               | a list of labels that would exclude services from list/export. example: "include=false"                                                                                     |
-| `--exclude-services`   |               | a list of service to exclude from list/export. example: "service1,service2"                                                                                                 |
+| `--exclude-labels`     |               | A list of labels that would exclude services from list/export. example: "include=false"                                                                                     |
+| `--exclude-services`   |               | A list of service to exclude from list/export. example: "service1,service2"                                                                                                 |
 
 #### Returns
 


### PR DESCRIPTION
This PR documents the CLI flags added in pull requests https://github.com/otterize/otterize-cli/pull/113 and https://github.com/otterize/otterize-cli/pull/122.