### PR TITLE
Add docs for support user specified annotation for servicename

### DIFF
--- a/docs/reference/configuration/credentials-operator/README.mdx
+++ b/docs/reference/configuration/credentials-operator/README.mdx
@@ -46,9 +46,6 @@ The operator consults the label `credentials-operator.otterize.com/tls-secret-na
 When using SPIRE, once the operator has registered the pod with SPIRE, which happens automatically upon startup, the pod can use the SPIRE Workload API to generate credentials for the SVID `<servicename>.<namespace>`.
 
 ### Service name resolution and automatic pod labeling
-Service name resolution is performed one of two ways:
-1. If an `intents.otterize.com/service-name` annotation is present, that name is used (`intents.otterize.com/service-name` can be changed to a custom annotation name when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`.).
-2. If not, a recursive look up is performed for the Kubernetes resource owner for a Pod until the root is reached. For example, if you have a `Deployment` named `client`, which then creates and owns a `ReplicaSet`, which then creates and owns a `Pod`, then the service name for that pod is `client` - same as the name of the `Deployment`.
-
-The value resulting from this process forms the value of the label `credentials-operator.otterize.com/service-name`.
+The operator performs service name resolution for each pod. You can read more about the resolution algorithm [here](/reference/service-identities#kubernetes-service-identity-resolution).
+The value resulting from this resolution process forms the value of the label `credentials-operator.otterize.com/service-name`.
 

--- a/docs/reference/configuration/credentials-operator/README.mdx
+++ b/docs/reference/configuration/credentials-operator/README.mdx
@@ -32,7 +32,7 @@ To learn more, check out the documentation for [SPIRE](https://spiffe.io/docs/la
 | `credentials-operator.otterize.com/truststore-file-name`               | Truststore key name in the secret. When mounted, this is the filename for the truststore. Only used when cert-type is `jks`.                                         | `truststore.jks`                                          |
 | `credentials-operator.otterize.com/jks-password`                       | Password for the JKS truststore and keystore. Only used when cert-type is `jks`.                                                                                     | `password`                                                |
 | `credentials-operator.otterize.com/restart-pod-on-certificate-renewal` | A pod with this annotation (no matter the value) will be restarted after certificate renewal, along with any replicas. Should be ideally set through the pod owner's `template` spec so it will persist between restarts. | N/A                                                   |
-| `intents.otterize.com/service-name`                                 | Otterize-wide override for this service's name. Used by the operator when registering the service with SPIRE and generating credentials. It can be changed when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`.                           | See [Service identities](/reference/service-identities)             |
+| `intents.otterize.com/service-name`                                 | Used for [service identity resolution](/reference/service-identities#kubernetes-service-identity-resolution).|             |
 
 ## How does the credentials operator work?
 

--- a/docs/reference/configuration/credentials-operator/README.mdx
+++ b/docs/reference/configuration/credentials-operator/README.mdx
@@ -32,7 +32,7 @@ To learn more, check out the documentation for [SPIRE](https://spiffe.io/docs/la
 | `credentials-operator.otterize.com/truststore-file-name`               | Truststore key name in the secret. When mounted, this is the filename for the truststore. Only used when cert-type is `jks`.                                         | `truststore.jks`                                          |
 | `credentials-operator.otterize.com/jks-password`                       | Password for the JKS truststore and keystore. Only used when cert-type is `jks`.                                                                                     | `password`                                                |
 | `credentials-operator.otterize.com/restart-pod-on-certificate-renewal` | A pod with this annotation (no matter the value) will be restarted after certificate renewal, along with any replicas. Should be ideally set through the pod owner's `template` spec so it will persist between restarts. | N/A                                                   |
-| `intents.otterize.com/service-name`                                 | Otterize-wide override for this service's name. Used by the operator when registering the service with SPIRE and generating credentials.                             | See [Service identities](/reference/service-identities)             |
+| `intents.otterize.com/service-name`                                 | Otterize-wide override for this service's name. Used by the operator when registering the service with SPIRE and generating credentials. It can be changed when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`.                           | See [Service identities](/reference/service-identities)             |
 
 ## How does the credentials operator work?
 
@@ -47,7 +47,7 @@ When using SPIRE, once the operator has registered the pod with SPIRE, which hap
 
 ### Service name resolution and automatic pod labeling
 Service name resolution is performed one of two ways:
-1. If an `intents.otterize.com/service-name` annotation is present, that name is used.
+1. If an `intents.otterize.com/service-name` annotation is present, that name is used (`intents.otterize.com/service-name` can be changed to a custom annotation name when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`.).
 2. If not, a recursive look up is performed for the Kubernetes resource owner for a Pod until the root is reached. For example, if you have a `Deployment` named `client`, which then creates and owns a `ReplicaSet`, which then creates and owns a `Pod`, then the service name for that pod is `client` - same as the name of the `Deployment`.
 
 The value resulting from this process forms the value of the label `credentials-operator.otterize.com/service-name`.

--- a/docs/reference/configuration/credentials-operator/helm-chart.mdx
+++ b/docs/reference/configuration/credentials-operator/helm-chart.mdx
@@ -23,6 +23,7 @@ If you would like to deploy it on its own, add the Otterize Helm chart repositor
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
+| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
 
 
 ## SPIRE parameters

--- a/docs/reference/configuration/credentials-operator/helm-chart.mdx
+++ b/docs/reference/configuration/credentials-operator/helm-chart.mdx
@@ -23,7 +23,7 @@ If you would like to deploy it on its own, add the Otterize Helm chart repositor
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
-| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
+| `global.serviceNameOverrideAnnotationName` | Which annotation to use (in the [service name resolution algorithm](/reference/service-identities#kubernetes-service-identity-resolution)) for setting a pod's service name, if not the default. Use this if you already have annotations on your pods that provide the correct service name.    | `intents.otterize.com/service-name` |
 
 
 ## SPIRE parameters

--- a/docs/reference/configuration/intents-operator/README.mdx
+++ b/docs/reference/configuration/intents-operator/README.mdx
@@ -26,9 +26,9 @@ To learn how to use the intents operator to control access, consult the guides f
 You can override the service name the intents operator uses when it computes network policies and Kafka ACLs with a pod annotation.
 
 
-| Annotation                          | Description                                                                                                                                          | Default                                       |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| `intents.otterize.com/service-name` | Otterize-wide override for this service's name. Used by the operator when computing a pod's service name for use in network policies and Kafka ACLs. The annotation namer can be changed to a custom annotation name when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`| See [Service identities](/reference/service-identities) |
+| Annotation                          | Description                                                                                                                                          |
+|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `intents.otterize.com/service-name` | Used for [service identity resolution](/reference/service-identities#kubernetes-service-identity-resolution).|
 
 ## Supported enforcement types
 

--- a/docs/reference/configuration/intents-operator/README.mdx
+++ b/docs/reference/configuration/intents-operator/README.mdx
@@ -28,7 +28,7 @@ You can override the service name the intents operator uses when it computes net
 
 | Annotation                          | Description                                                                                                                                          | Default                                       |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| `intents.otterize.com/service-name` | Otterize-wide override for this service's name. Used by the operator when computing a pod's service name for use in network policies and Kafka ACLs. | See [Service identities](/reference/service-identities) |
+| `intents.otterize.com/service-name` | Otterize-wide override for this service's name. Used by the operator when computing a pod's service name for use in network policies and Kafka ACLs. The annotation namer can be changed to a custom annotation name when installing the operator by setting the value of `global.serviceNameOverrideAnnotationName`| See [Service identities](/reference/service-identities) |
 
 ## Supported enforcement types
 

--- a/docs/reference/configuration/intents-operator/helm-chart.mdx
+++ b/docs/reference/configuration/intents-operator/helm-chart.mdx
@@ -20,12 +20,12 @@ If you would like to deploy it on its own, add the Otterize Helm chart repositor
 | Key                              | Description                                                                                                                                 | Default |
 |:---------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `global.allowGetAllResources`    | If defined overrides `allowGetAllResources`.                                                                                                |         |
-| `global.telemetry.enabled`       | If set to `false`, anonymous telemetries collection will be disabled                                                                        | `true`  |
-| `global.commonAnnotations`       | Annotations to add to all deployed objects                                                                                                  | {}      |
-| `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
-| `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
-| `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
-| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
+| `global.telemetry.enabled`       | If set to `false`, anonymous telemetries collection will be disabled.                                                                       | `true`  |
+| `global.commonAnnotations`       | Annotations to add to all deployed objects.                                                                                                 | {}      |
+| `global.commonLabels`            | Labels to add to all deployed objects.                                                                                                      | {}      |
+| `global.podAnnotations`          | Annotations to add to all deployed pods.                                                                                                    | {}      |
+| `global.podLabels`               | Labels to add to all deployed pods.                                                                                                         | {}      |
+| `global.serviceNameOverrideAnnotationName` | Which annotation to use (in the [service name resolution algorithm](/reference/service-identities#kubernetes-service-identity-resolution)) for setting a pod's service name, if not the default. Use this if you already have annotations on your pods that provide the correct service name.  | `intents.otterize.com/service-name` |
 
 
 ## Operator parameters

--- a/docs/reference/configuration/intents-operator/helm-chart.mdx
+++ b/docs/reference/configuration/intents-operator/helm-chart.mdx
@@ -25,6 +25,7 @@ If you would like to deploy it on its own, add the Otterize Helm chart repositor
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
+| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
 
 
 ## Operator parameters

--- a/docs/reference/configuration/network-mapper/README.mdx
+++ b/docs/reference/configuration/network-mapper/README.mdx
@@ -63,6 +63,6 @@ To deploy the network mapper, [use the Helm chart](/reference/configuration/netw
 You can override the service name the network mapper uses when it computes the service name using a pod annotation.
 
 
-| Annotation                          | Description                                     | Default                                       |
-|-------------------------------------|-------------------------------------------------|-----------------------------------------------|
-| `intents.otterize.com/service-name` | Otterize-wide override for this service's name. | See [Service identities](/reference/service-identities) |
+| Annotation                          | Description                                     |
+|-------------------------------------|-------------------------------------------------|
+| `intents.otterize.com/service-name` | Used for [service identity resolution](/reference/service-identities#kubernetes-service-identity-resolution). |

--- a/docs/reference/configuration/network-mapper/helm-chart.mdx
+++ b/docs/reference/configuration/network-mapper/helm-chart.mdx
@@ -76,7 +76,7 @@ Checkout the network mapper [tutorial](/quick-tutorials/k8s-network-mapper) to s
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
-| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
+| `global.serviceNameOverrideAnnotationName` | Which annotation to use (in the [service name resolution algorithm](/reference/service-identities#kubernetes-service-identity-resolution)) for setting a pod's service name, if not the default. Use this if you already have annotations on your pods that provide the correct service name. | `intents.otterize.com/service-name` |
 
 
 ## Common parameters

--- a/docs/reference/configuration/network-mapper/helm-chart.mdx
+++ b/docs/reference/configuration/network-mapper/helm-chart.mdx
@@ -76,6 +76,7 @@ Checkout the network mapper [tutorial](/quick-tutorials/k8s-network-mapper) to s
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
+| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
 
 
 ## Common parameters

--- a/docs/reference/configuration/otterize-chart/README.mdx
+++ b/docs/reference/configuration/otterize-chart/README.mdx
@@ -33,7 +33,7 @@ These parameters are used by multiple charts, and must be kept the same for the 
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
-| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
+| `global.serviceNameOverrideAnnotationName` | Which annotation to use (in the [service name resolution algorithm](/reference/service-identities#kubernetes-service-identity-resolution)) for setting a pod's service name, if not the default. Use this if you already have annotations on your pods that provide the correct service name.  | `intents.otterize.com/service-name` |
 
 
 ## Cloud parameters

--- a/docs/reference/configuration/otterize-chart/README.mdx
+++ b/docs/reference/configuration/otterize-chart/README.mdx
@@ -33,6 +33,8 @@ These parameters are used by multiple charts, and must be kept the same for the 
 | `global.commonLabels`            | Labels to add to all deployed objects                                                                                                       | {}      |
 | `global.podAnnotations`          | Annotations to add to all deployed pods                                                                                                     | {}      |
 | `global.podLabels`               | Labels to add to all deployed pods                                                                                                          | {}      |
+| `global.serviceNameOverrideAnnotationName` | Specify an annotation name that by setting it, one can override otterize's service name resolution.                                                                                                                                                                                                                                                                                                                                                                                                                     | `intents.otterize.com/service-name` |
+
 
 ## Cloud parameters
 | Key                                                        | Description                                                                                                                                                                                  | Default  |

--- a/docs/reference/service-identities/README.mdx
+++ b/docs/reference/service-identities/README.mdx
@@ -8,11 +8,13 @@ Otterize uses universal service identities to refer to services, regardless of w
 ## Kubernetes service identity resolution
 How do Otterize operators decide what is the name of the service that runs within the pod? The algorithm is as follows:
 
-1. If the pod has an `intents.otterize.com/service-name` label, its value is used as the service name. This allows developers and
+1. If the pod has an `intents.otterize.com/service-name` annotation, its value is used as the service name. This allows developers and
    automations to explicitly name services, if needed. The value must not contain a period `.` as a period is used to separate service name and namespace, when the service is from a different namespace: `svcname.namespace`.
-2. If there is no `intents.otterize.com/service-name` label, a recursive look-up is performed for the Kubernetes resource owner of
+2. If there is no `intents.otterize.com/service-name` annotation, a recursive look-up is performed for the Kubernetes resource owner of
    the pod, until the root resource is reached, and its name is used as the service name. For example, if you have
    a `Deployment` named `checkoutservice`, which then creates and owns a `ReplicaSet`, which then creates and owns
    a `Pod`, then the service name for that pod is `checkoutservice` - same as the name of the `Deployment`. This is
    intended to capture the likely-more-meaningful "human name" of the service. If the resulting service name contains
    a period `.`, it is replaced with an underscore `_`. Periods are used in service names to denote namespaces, e.g. `svcname.namespace`.
+
+* Custom annotation can be set instead of `intents.otterize.com/service-name` (fo more information go to the [otterize helm chart documentation](/reference/configuration/otterize-chart#global-parameters)).

--- a/docs/reference/service-identities/README.mdx
+++ b/docs/reference/service-identities/README.mdx
@@ -8,7 +8,7 @@ Otterize uses universal service identities to refer to services, regardless of w
 ## Kubernetes service identity resolution
 How do Otterize operators decide what is the name of the service that runs within the pod? The algorithm is as follows:
 
-1. If the pod has an `intents.otterize.com/service-name` annotation, its value is used as the service name. This allows developers and
+1. If the pod has an `intents.otterize.com/service-name` annotation, its value is used as the service name. (You can change which annotation is used by setting `global.serviceNameOverrideAnnotationName` &mdash; see the [docs](/reference/configuration/otterize-chart#global-parameters).) This allows developers and
    automations to explicitly name services, if needed. The value must not contain a period `.` as a period is used to separate service name and namespace, when the service is from a different namespace: `svcname.namespace`.
 2. If there is no `intents.otterize.com/service-name` annotation, a recursive look-up is performed for the Kubernetes resource owner of
    the pod, until the root resource is reached, and its name is used as the service name. For example, if you have
@@ -16,5 +16,3 @@ How do Otterize operators decide what is the name of the service that runs withi
    a `Pod`, then the service name for that pod is `checkoutservice` - same as the name of the `Deployment`. This is
    intended to capture the likely-more-meaningful "human name" of the service. If the resulting service name contains
    a period `.`, it is replaced with an underscore `_`. Periods are used in service names to denote namespaces, e.g. `svcname.namespace`.
-
-* Custom annotation can be set instead of `intents.otterize.com/service-name` (fo more information go to the [otterize helm chart documentation](/reference/configuration/otterize-chart#global-parameters)).


### PR DESCRIPTION

### Description

Following https://github.com/otterize/network-mapper/issues/128 , adding support for user-specified annotation for service name override.

### References

https://github.com/otterize/intents-operator/pull/240
https://github.com/otterize/helm-charts/pull/111
 https://github.com/otterize/network-mapper/issues/128 


