### PR TITLE
Remove references to SPIRE where no longer relevant

### DIFF
--- a/docs/_common/install-otterize-istio-enabled.md
+++ b/docs/_common/install-otterize-istio-enabled.md
@@ -10,7 +10,7 @@
 
 :::note This example disable network policy enforcement. 
 
-This chart is a bundle of the Otterize intents operator, Otterize credentials operator, Otterize network mapper, and SPIRE.
+This chart is a bundle of the Otterize intents operator, Otterize credentials operator, Otterize network mapper.
 Initial deployment may take a couple of minutes.
 You can add the `--wait` flag for Helm to wait for deployment to complete and all pods to be Ready, or manually watch for all pods to be `Ready` using `kubectl get pods -n otterize-system -w`.
 
@@ -22,7 +22,5 @@ credentials-operator-controller-manager-6c56fcfcfb-vg6m9   2/2    Running   0   
 intents-operator-controller-manager-65bb6d4b88-bp9pf       2/2    Running   0     9s
 otterize-network-mapper-779fffd959-twjqd                   1/1    Running   0     9s
 otterize-network-sniffer-65mjt                             1/1    Running   0     9s
-otterize-spire-agent-lcbq2                                 1/1    Running   0     9s
-otterize-spire-server-0                                    2/2    Running   0     9s
 otterize-watcher-b9bf87bcd-276nt                           1/1    Running   0     9s
 ```

--- a/docs/_common/install-otterize-istio-enabled.md
+++ b/docs/_common/install-otterize-istio-enabled.md
@@ -8,7 +8,7 @@
    --set intentsOperator.operator.enableNetworkPolicyCreation=false
    ```
 
-:::note This example disable network policy enforcement. 
+:::note This example disables network policy enforcement. 
 
 This chart is a bundle of the Otterize intents operator, the Otterize credentials operator, and the Otterize network mapper.
 Initial deployment may take a couple of minutes.
@@ -24,3 +24,4 @@ otterize-network-mapper-779fffd959-twjqd                   1/1    Running   0   
 otterize-network-sniffer-65mjt                             1/1    Running   0     9s
 otterize-watcher-b9bf87bcd-276nt                           1/1    Running   0     9s
 ```
+:::

--- a/docs/_common/install-otterize-istio-watcher.md
+++ b/docs/_common/install-otterize-istio-watcher.md
@@ -6,7 +6,7 @@ You'll need [Helm](https://helm.sh/docs/intro/install/) installed on your machin
    helm install otterize otterize/otterize-kubernetes -n otterize-system --create-namespace --set networkMapper.istiowatcher.enable=true
    ```
 
-This chart is a bundle of the Otterize intents operator, Otterize credentials operator, Otterize network mapper with the Istio watcher componenet enabled, and SPIRE.
+This chart is a bundle of the Otterize intents operator, Otterize credentials operator, Otterize network mapper with the Istio watcher component enabled.
 Initial deployment may take a couple of minutes.
 You can add the `--wait` flag for Helm to wait for deployment to complete and all pods to be Ready, or manually watch for all pods to be `Ready` using `kubectl get pods -n otterize-system -w`.
 
@@ -19,7 +19,5 @@ intents-operator-controller-manager-65bb6d4b88-bp9pf       2/2    Running   0   
 otterize-istio-watcher-5c664987d-2mvw9                     1/1    Running   0     9s
 otterize-network-mapper-779fffd959-twjqd                   1/1    Running   0     9s
 otterize-network-sniffer-65mjt                             1/1    Running   0     9s
-otterize-spire-agent-lcbq2                                 1/1    Running   0     9s
-otterize-spire-server-0                                    2/2    Running   0     9s
 otterize-watcher-b9bf87bcd-276nt                           1/1    Running   0     9s
 ```

--- a/docs/quick-tutorials/k8s-istio-authorization-policies.mdx
+++ b/docs/quick-tutorials/k8s-istio-authorization-policies.mdx
@@ -32,7 +32,6 @@ Before you start, you'll need a Kubernetes cluster. Having a cluster with a [CNI
 
 You can now install (or reinstall) Otterize in your cluster, and optionally connect to Otterize Cloud. Connecting to Cloud lets you:
 1. See what's happening visually in your browser, through the "access graph";
-2. Avoid using SPIRE (which can be installed with Otterize) for issuing certificates, as Otterize Cloud provides a certificate service.
 
 So either forego browser visualization and:
 

--- a/docs/quick-tutorials/k8s-istio-authorization-policies.mdx
+++ b/docs/quick-tutorials/k8s-istio-authorization-policies.mdx
@@ -38,9 +38,6 @@ So either forego browser visualization and:
 <details>
 <summary>Install Otterize in your cluster, <b>without</b> Otterize Cloud</summary>
 
-:::note Basic system memory requirements
-Otterize requires about 200 MBs and 200 mCPU for all components (including a SPIRE deployment) to install and run properly on Minikube and EKS clusters.
-
 {@include: ../_common/install-otterize-istio-enabled.md}
 
 </details>

--- a/docs/quick-tutorials/k8s-istio-watcher.mdx
+++ b/docs/quick-tutorials/k8s-istio-watcher.mdx
@@ -26,7 +26,6 @@ Before you start, you'll need a Kubernetes cluster. Having a cluster with a [CNI
 
 You can now install Otterize in your cluster, and optionally connect to Otterize Cloud. Connecting to Cloud lets you:
 1. See what's happening visually in your browser, through the "access graph";
-2. Avoid using SPIRE (which can be installed with Otterize) for issuing certificates, as Otterize Cloud provides a certificate service.
 
 So either forego browser visualization and:
 

--- a/docs/quick-tutorials/k8s-mtls.mdx
+++ b/docs/quick-tutorials/k8s-mtls.mdx
@@ -34,10 +34,6 @@ So either forego browser visualization and:
 <details>
 <summary>Install Otterize in your cluster, <b>without</b> Otterize Cloud</summary>
 
-:::note Basic system memory requirements
-Otterize requires about 200 MBs and 200 mCPU for all components (including a SPIRE deployment) to install and run properly on Minikube and EKS clusters.
-:::
-
 {@include: ../_common/install-otterize-mtls.md}
 
 </details>

--- a/docs/quick-tutorials/k8s-network-policies.mdx
+++ b/docs/quick-tutorials/k8s-network-policies.mdx
@@ -38,10 +38,6 @@ So either forego browser visualization and:
 <details>
 <summary>Install Otterize in your cluster, <b>without</b> Otterize Cloud</summary>
 
-:::note Basic system memory requirements
-Otterize requires about 200 MBs and 200 mCPU for all components (including a SPIRE deployment) to install and run properly on Minikube and EKS clusters.
-:::
-
 {@include: ../_common/install-otterize.md}
 
 </details>


### PR DESCRIPTION
Previously, SPIRE was deployed by default. It is now no longer deployed by default, and this PR removes references to configuring it in tutorials where it is not used.