### PR TITLE
Redirect tutorials from old path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,14 @@ const config = {
           from: '/quick-tutorials/k8s-mtls',
           to: '/quickstart/access-control/k8s-mtls',
         },
+        {
+          from: '/quick-tutorials/k8s-network-mapper',
+          to: 'quickstart/visualization/k8s-network-mapper',
+        },
+        {
+          from: '/quick-tutorials/k8s-istio-watcher',
+          to: 'quickstart/visualization/k8s-istio-watcher',
+        },
         // Redirect from multiple old paths to the new path
         // {
         //   to: '/docs/newDoc2',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,11 +64,11 @@ const config = {
         },
         {
           from: '/quick-tutorials/k8s-network-mapper',
-          to: 'quickstart/visualization/k8s-network-mapper',
+          to: '/quickstart/visualization/k8s-network-mapper',
         },
         {
           from: '/quick-tutorials/k8s-istio-watcher',
-          to: 'quickstart/visualization/k8s-istio-watcher',
+          to: '/quickstart/visualization/k8s-istio-watcher',
         },
         // Redirect from multiple old paths to the new path
         // {


### PR DESCRIPTION
### Description
Since we changed those tutorials path,
added redirect declarations from the old path to the new one, 
so that links from external websites will keep working.