### PR TITLE
Documentation for OpenTelemetry exporter

### DIFF
--- a/docs/reference/configuration/network-mapper/README.mdx
+++ b/docs/reference/configuration/network-mapper/README.mdx
@@ -8,7 +8,9 @@ The Otterize network mapper creates a map of in-cluster traffic by (1) capturing
 You can then use the Otterize CLI to list the traffic by client, reset the traffic the mapper remembers, or export it as JSON or YAML, which serves as ClientIntents Kubernetes resources). ClientIntents can be consumed by the [Otterize intents operator](/reference/configuration/intents-operator) to apply network policies
 or Kafka ACLs to your cluster, implementing [intent-based access control](/intent-based-access-control).
 
-To get started, follow the [quick hands-on tutorial](/quickstart/visualization/k8s-network-mapper)
+To get started, follow the [quick hands-on tutorial](/quickstart/visualization/k8s-network-mapper).
+
+The network mapper also supports exporting Grafana Tempo-style metrics, contributed by the community. See the [Helm chart documentation's OpenTelemetry section](/reference/configuration/network-mapper/helm-chart#opentelemetry-exporter-parameters) to learn how to enable this feature.
 
 ```shell
 cartservice in namespace otterize-ecom-demo calls:

--- a/docs/reference/configuration/network-mapper/helm-chart.mdx
+++ b/docs/reference/configuration/network-mapper/helm-chart.mdx
@@ -13,14 +13,21 @@ Checkout the network mapper [tutorial](/quickstart/visualization/k8s-network-map
 # Parameters
 
 ## Mapper parameters
-| Key                            | Description                          | Default                        |
-|--------------------------------|--------------------------------------|--------------------------------|
-| `mapper.image.repository`      | Mapper image repository.             | `otterize`                     |
-| `mapper.image.image`           | Mapper image.                        | `network-mapper`               |
-| `mapper.image.tag`             | Mapper image tag.                    | `latest`                       |
-| `mapper.pullPolicy`            | Mapper pull policy.                  | `(none)`                       |
-| `mapper.resources`             | Resources override.                  | `(none)`                       |
-| `mapper.uploadIntervalSeconds` | Interval for uploading data to cloud | `60`                           |
+| Key                            | Description                                                                                     | Default          |
+|--------------------------------|-------------------------------------------------------------------------------------------------|------------------|
+| `mapper.image.repository`      | Mapper image repository.                                                                        | `otterize`       |
+| `mapper.image.image`           | Mapper image.                                                                                   | `network-mapper` |
+| `mapper.image.tag`             | Mapper image tag.                                                                               | `latest`         |
+| `mapper.pullPolicy`            | Mapper pull policy.                                                                             | `(none)`         |
+| `mapper.resources`             | Resources override.                                                                             | `(none)`         |
+| `mapper.uploadIntervalSeconds` | Interval for uploading data to cloud                                                            | `60`             |
+| `mapper.extraEnvVars`          | List of extra env vars for the mapper, formatted as in the Kubernetes PodSpec (name and value). | `(none)`         |
+
+## OpenTelemetry exporter parameters
+| Key                        | Description                                                                                                                                                                                                     | Default                              |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `opentelemetry.enable`     | Whether to enable the OpenTelemetry exporter, which exports Grafana Tempo-style metrics for your network map. Configure the OpenTelemetry SDK using `mapper.extraEnvVars` (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`). | `false`                              |
+| `opentelemetry.metricName` | The name of the OpenTelemetry metric name exported for the Grafana Tempo-style metric.                                                                                                                          | `traces_service_graph_request_total` |
 
 ## Sniffer parameters
 | Key                         | Description               | Default                  |


### PR DESCRIPTION
### Description

This PR adds documentation for the OpenTelemetry exporter that exports Grafana Tempo-style metrics, contributed by @smithclay from Lightstep/ServiceNow in https://github.com/otterize/network-mapper/pull/141.

### References

https://github.com/otterize/network-mapper/pull/141
