### PR TITLE
Correct new HTTP resources field name

### DIFF
--- a/static/code-examples/kafka-mapping/helm/values.yaml
+++ b/static/code-examples/kafka-mapping/helm/values.yaml
@@ -7,7 +7,7 @@ advertisedListeners:
 # For a gradual rollout scenario we will want to keep the default permission for topics as allowed, unless an ACL was set
 allowEveryoneIfNoAclFound: true
 # Allocate resources
-HTTPResources:
+resources:
   requests:
     cpu: 50m
     memory: 256Mi

--- a/static/code-examples/kafka-mtls-cert-manager/helm/values.yaml
+++ b/static/code-examples/kafka-mtls-cert-manager/helm/values.yaml
@@ -28,7 +28,7 @@ auth:
     jksKeystoreSAN: keystore.jks
 authorizerClassName: kafka.security.authorizer.AclAuthorizer
 # Allocate resources
-HTTPResources:
+resources:
   requests:
     cpu: 50m
     memory: 256Mi

--- a/static/code-examples/kafka-mtls/helm/values.yaml
+++ b/static/code-examples/kafka-mtls/helm/values.yaml
@@ -28,7 +28,7 @@ auth:
     jksKeystoreSAN: keystore.jks
 authorizerClassName: kafka.security.authorizer.AclAuthorizer
 # Allocate resources
-HTTPResources:
+resources:
   requests:
     cpu: 50m
     memory: 256Mi

--- a/static/code-examples/microservices-demo/kubernetes-manifests.yml
+++ b/static/code-examples/microservices-demo/kubernetes-manifests.yml
@@ -65,7 +65,7 @@ spec:
             periodSeconds: 5
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -143,7 +143,7 @@ spec:
               value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -212,7 +212,7 @@ spec:
               value: "1"
             - name: DISABLE_DEBUGGER
               value: "1"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -308,7 +308,7 @@ spec:
           #   value: "jaeger-collector:14268"
           # - name: CYMBAL_BRANDING
           #   value: "true"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -386,7 +386,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -453,7 +453,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:3550"]
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -506,7 +506,7 @@ spec:
           env:
             - name: REDIS_ADDR
               value: "redis-cart:6379"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -588,7 +588,7 @@ spec:
               value: "frontend:80"
             - name: USERS
               value: "10"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -641,7 +641,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:7000"]
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -708,7 +708,7 @@ spec:
           livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -767,7 +767,7 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: redis-data
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi
@@ -829,7 +829,7 @@ spec:
               value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 50m
               memory: 50Mi

--- a/static/code-examples/shadow-mode/ecom-demo-mtls.yaml
+++ b/static/code-examples/shadow-mode/ecom-demo-mtls.yaml
@@ -450,7 +450,7 @@ spec:
           value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -505,7 +505,7 @@ spec:
         env:
         - name: REDIS_ADDR
           value: "redis-cart:6379"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -606,7 +606,7 @@ spec:
             value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -674,7 +674,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -735,7 +735,7 @@ spec:
           periodSeconds: 5
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -831,7 +831,7 @@ spec:
           #   value: "jaeger-collector:14268"
           # - name: CYMBAL_BRANDING
           #   value: "true"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -898,7 +898,7 @@ spec:
           value: "frontend:80"
         - name: USERS
           value: "10"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -956,7 +956,7 @@ spec:
             value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -1037,7 +1037,7 @@ spec:
           - name: otterize-credentials
             mountPath: /var/otterize/credentials
             readOnly: true
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1098,7 +1098,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1161,7 +1161,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1214,7 +1214,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: redis-data
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1282,7 +1282,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1352,7 +1352,7 @@ spec:
             runAsUser: 1001
           command:
             - /scripts/setup.sh
-          HTTPResources:
+          resources:
             limits: {}
             requests:
               cpu: 250m
@@ -1443,7 +1443,7 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        HTTPResources:
+        resources:
           requests:
             storage: "8Gi"
 ---
@@ -1627,7 +1627,7 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
-          HTTPResources:
+          resources:
             limits: {}
             requests:
               cpu: 50m
@@ -1660,7 +1660,7 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        HTTPResources:
+        resources:
           requests:
             storage: "8Gi"
 ---
@@ -1670,7 +1670,7 @@ metadata:
   name: statefulset-reader
 rules:
   - apiGroups: ["apps"]
-    HTTPResources: ["statefulsets"]
+    resources: ["statefulsets"]
     verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/static/code-examples/shadow-mode/ecom-demo.yaml
+++ b/static/code-examples/shadow-mode/ecom-demo.yaml
@@ -439,7 +439,7 @@ spec:
           value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -496,7 +496,7 @@ spec:
         env:
         - name: REDIS_ADDR
           value: "redis-cart:6379"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -591,7 +591,7 @@ spec:
             value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -651,7 +651,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -712,7 +712,7 @@ spec:
           periodSeconds: 5
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -806,7 +806,7 @@ spec:
           #   value: "jaeger-collector:14268"
           # - name: CYMBAL_BRANDING
           #   value: "true"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -873,7 +873,7 @@ spec:
           value: "frontend:80"
         - name: USERS
           value: "10"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -927,7 +927,7 @@ spec:
             value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
-          HTTPResources:
+          resources:
             requests:
               cpu: 30m
               memory: 50Mi
@@ -982,7 +982,7 @@ spec:
             value: "kafka-headless:9092"
           - name: KAFKA_PAYMENT_SERVICE_TOPIC
             value: payments
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1043,7 +1043,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1106,7 +1106,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1159,7 +1159,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: redis-data
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1227,7 +1227,7 @@ spec:
         livenessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
-        HTTPResources:
+        resources:
           requests:
             cpu: 30m
             memory: 50Mi
@@ -1297,7 +1297,7 @@ spec:
             runAsUser: 1001
           command:
             - /scripts/setup.sh
-          HTTPResources:
+          resources:
             limits: {}
             requests:
               cpu: 250m
@@ -1388,7 +1388,7 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        HTTPResources:
+        resources:
           requests:
             storage: "8Gi"
 ---
@@ -1559,7 +1559,7 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
-          HTTPResources:
+          resources:
             limits: {}
             requests:
               cpu: 50m
@@ -1585,7 +1585,7 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        HTTPResources:
+        resources:
           requests:
             storage: "8Gi"
 ---
@@ -1595,7 +1595,7 @@ metadata:
   name: statefulset-reader
 rules:
   - apiGroups: ["apps"]
-    HTTPResources: ["statefulsets"]
+    resources: ["statefulsets"]
     verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### Description

This PR fixes a problem in a previous change that accidentally replaced 'resources' in Deployments with 'HTTPResources'.