### PR TITLE
Kafka tutorial: add client intents for Kafka server

### DIFF
--- a/static/code-examples/kafka-mtls/client-intents.yaml
+++ b/static/code-examples/kafka-mtls/client-intents.yaml
@@ -1,7 +1,7 @@
 apiVersion: k8s.otterize.com/v1alpha3
 kind: ClientIntents
 metadata:
-  name: client-intents-for-client
+  name: client
   namespace: otterize-tutorial-kafka-mtls
 spec:
   service:

--- a/static/code-examples/kafka-mtls/client-intents.yaml
+++ b/static/code-examples/kafka-mtls/client-intents.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: k8s.otterize.com/v1alpha3
 kind: ClientIntents
 metadata:
-  name: client-intents-for-kafka
+  name: kafka
   namespace: kafka
 spec:
   service:

--- a/static/code-examples/kafka-mtls/client-intents.yaml
+++ b/static/code-examples/kafka-mtls/client-intents.yaml
@@ -1,8 +1,20 @@
 apiVersion: k8s.otterize.com/v1alpha3
 kind: ClientIntents
 metadata:
-  name: client
-  namespace:  otterize-tutorial-kafka-mtls
+  name: client-intents-for-kafka
+  namespace: kafka
+spec:
+  service:
+    name: kafka
+  calls:
+    - name: kafka
+    - name: kafka-zookeeper
+---
+apiVersion: k8s.otterize.com/v1alpha3
+kind: ClientIntents
+metadata:
+  name: client-intents-for-client
+  namespace: otterize-tutorial-kafka-mtls
 spec:
   service:
     name: client

--- a/static/code-examples/kafka-mtls/client-intents.yaml
+++ b/static/code-examples/kafka-mtls/client-intents.yaml
@@ -1,18 +1,6 @@
 apiVersion: k8s.otterize.com/v1alpha3
 kind: ClientIntents
 metadata:
-  name: client-intents-for-kafka
-  namespace: kafka
-spec:
-  service:
-    name: kafka
-  calls:
-    - name: kafka
-    - name: kafka-zookeeper
----
-apiVersion: k8s.otterize.com/v1alpha3
-kind: ClientIntents
-metadata:
   name: client-intents-for-client
   namespace: otterize-tutorial-kafka-mtls
 spec:
@@ -26,3 +14,16 @@ spec:
           operations: [ produce,describe,consume ]
         - name: transactions
           operations: [ produce,describe,consume ]
+---
+apiVersion: k8s.otterize.com/v1alpha3
+kind: ClientIntents
+metadata:
+  name: client-intents-for-kafka
+  namespace: kafka
+spec:
+  service:
+    name: kafka
+  calls:
+    - name: kafka
+    - name: kafka-zookeeper
+


### PR DESCRIPTION
### Description

During the Kafka tutorial the server will show missing intents for the Kafka server itself, as part of its client intents list. To make sure the user will focus only on the tutorial use case, this PR add intents for the server itself.
