### PR TITLE
Add explanation for username and password secret in PGSQL tutorial

### DIFF
--- a/docs/quickstart/access-control/postgres.mdx
+++ b/docs/quickstart/access-control/postgres.mdx
@@ -62,9 +62,18 @@ We will be using it to create a proxy to connect our locally running database to
 
 # Tutorial
 
-### Deploy the cluster
+### Deploy tutorial services and request database credentials
+This will set up the namespace we will use for our tutorial and deploy the client, server, and database.
 
-This will set up the namespace we will use for our tutorial and deploy the cluster with our client, server, and database.
+Our server's Deployment spec will specify an annotation on the Pod, which requests that the credentials operator will provision a username and password for the server.
+```yaml
+  template:
+    metadata:
+      annotations:
+        credentials-operator.otterize.com/user-password-secret-name: server-creds
+```
+This specifies that the secret `server-creds` will have keys with the username and password to connect to the database.
+The secret will only be created once the database is integrated with Otterize Cloud.
 
 ``` shell
 kubectl create namespace otterize-tutorial-postgres
@@ -112,6 +121,7 @@ After providing a cluster name and environment. For this tutorial, choose:
 2. Enforcement mode: Enabled.
 3. Copy and run the Helm upgrade command.
 4. You should see the Connection status change.
+
 
 ### View logs for the server
 After the client, server, and database are up and running, we can see that the server does not have the appropriate access to the database by inspecting the logs with the following command.


### PR DESCRIPTION
The tutorial was missing an explanation for how to provision the username and password.