### PR TITLE
Replace links to the clusters page with the integrations page.

### DIFF
--- a/docs/features/istio/tutorials/k8s-istio-authorization-policies.mdx
+++ b/docs/features/istio/tutorials/k8s-istio-authorization-policies.mdx
@@ -29,7 +29,7 @@ Already have Otterize deployed with Istio configured on your cluster? Skip to th
 ### 1. Deploy Otterize
 If you do not have a cluster, we will need to prepare one with [network policy support](/overview/installation#create-a-cluster-with-support-for-network-policies)
 
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
 
 ### 2. Install and configure Istio
 

--- a/docs/features/istio/tutorials/k8s-istio-watcher.mdx
+++ b/docs/features/istio/tutorials/k8s-istio-watcher.mdx
@@ -21,7 +21,7 @@ In this tutorial, we will:
 Already have Otterize deployed with Istio configured on your cluster? Skip to the [tutorial](#tutorial).
 
 ### 1. Deploy Otterize
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
 
 
 ### 2. Install and configure Istio

--- a/docs/features/kafka/tutorials/k8s-kafka-mapping.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mapping.mdx
@@ -22,7 +22,7 @@ We will **not** be doing any access control in this demo, just purely mapping cl
 Already have Otterize & a Kafka broker deployed on your cluster? Skip to the [tutorial](#tutorial).
 
 ### 1. Deploy Otterize
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
 
 ### 2. Install Kafka
 

--- a/docs/features/kafka/tutorials/k8s-kafka-mtls-cert-manager.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mtls-cert-manager.mdx
@@ -55,7 +55,7 @@ You may have to wait for `cert-manager` to start successfully before you are abl
 Already have Otterize & a Kafka broker deployed on your cluster? Skip to the [tutorial](#tutorial).
 
 #### Deploy Otterize
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
 
 ##### Note:
 * Under mTLS and Kafka support choose **cert-manager**.

--- a/docs/features/kafka/tutorials/k8s-kafka-mtls.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mtls.mdx
@@ -24,7 +24,7 @@ In this tutorial, we will:
 Already have Otterize & a Kafka broker deployed on your cluster? Skip to the [tutorial](#tutorial).
 
 ### 1. Deploy Otterize
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions. If you already have a Kubernetes cluster connected, skip this step.
 
 ##### Note:
 * Under mTLS and Kafka support choose **Otterize Cloud**.

--- a/docs/features/network-mapping-network-policies/tutorials/aws-eks-cni-mini.mdx
+++ b/docs/features/network-mapping-network-policies/tutorials/aws-eks-cni-mini.mdx
@@ -81,7 +81,7 @@ Once your AWS EKS has finished deploying the control pane and node group, the ne
 
 ### Install Otterize on your cluster
 
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions.
 
 ### Deploy a server and two clients
 

--- a/docs/features/network-mapping-network-policies/tutorials/k8s-network-mapper.mdx
+++ b/docs/features/network-mapping-network-policies/tutorials/k8s-network-mapper.mdx
@@ -18,7 +18,7 @@ In this tutorial, we will:
 ## Prerequisites
 
 ### Install Otterize on your cluster
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions.
 
 We will also need the [Otterize CLI](/overview/installation#install-the-otterize-cli).
 

--- a/docs/features/network-mapping-network-policies/tutorials/k8s-network-policies.mdx
+++ b/docs/features/network-mapping-network-policies/tutorials/k8s-network-policies.mdx
@@ -24,7 +24,7 @@ In this tutorial, we will:
 ## Prerequisites
 
 ### Install Otterize on your cluster
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and associate a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions.
 
 We will also need the [Otterize CLI](/overview/installation#install-the-otterize-cli).
 

--- a/docs/features/network-mapping-network-policies/tutorials/protect-1-service-network-policies.mdx
+++ b/docs/features/network-mapping-network-policies/tutorials/protect-1-service-network-policies.mdx
@@ -29,7 +29,7 @@ Note: all the capabilities of IBAC are within Otterize OSS, while the access gra
 ### Install Otterize on your cluster
 If you do not have a cluster, we will need to prepare one with [network policy support](/overview/installation#create-a-cluster-with-support-for-network-policies)
 
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Clusters page](https://app.otterize.com/clusters), and follow the instructions.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com) and create a Kubernetes cluster on the [Integrations page](https://app.otterize.com/integrations), and follow the instructions.
 
 We will also need the [Otterize CLI](/overview/installation#install-the-otterize-cli).
 


### PR DESCRIPTION
Updates the docs to point to the Integrations page and not the previously noted Clusters page, which has been removed. 