### PR TITLE
Use Bitnami Kafka Helm chart mirror

### DIFF
--- a/docs/features/kafka/tutorials/k8s-kafka-mapping.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mapping.mdx
@@ -44,10 +44,10 @@ In the chart we will configure Kafka to:
 The following command will deploy a Kafka broker with this chart:
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add otterize https://helm.otterize.com
 helm repo update
 helm install --create-namespace -n kafka \
-  -f ${ABSOLUTE_URL}/code-examples/kafka-mapping/helm/values.yaml kafka bitnami/kafka --version 21.4.4
+  -f ${ABSOLUTE_URL}/code-examples/kafka-mapping/helm/values.yaml kafka otterize/bitnami-kafka --version 21.4.4
 ```
 
 ## Tutorial

--- a/docs/features/kafka/tutorials/k8s-kafka-mtls-cert-manager.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mtls-cert-manager.mdx
@@ -92,10 +92,10 @@ In the chart we will configure Kafka to:
 The following command will deploy a Kafka broker with this chart:
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add otterize https://helm.otterize.com
 helm repo update
 helm install --create-namespace -n kafka \
-  -f ${ABSOLUTE_URL}/code-examples/kafka-mtls-cert-manager/helm/values.yaml kafka bitnami/kafka --version 21.4.4
+  -f ${ABSOLUTE_URL}/code-examples/kafka-mtls-cert-manager/helm/values.yaml kafka otterize/bitnami-kafka --version 21.4.4
 ```
 
 You can watch for all pods to be `Ready` using `kubectl get pods -n kafka -w`.

--- a/docs/features/kafka/tutorials/k8s-kafka-mtls.mdx
+++ b/docs/features/kafka/tutorials/k8s-kafka-mtls.mdx
@@ -60,10 +60,10 @@ In the chart we will configure Kafka to:
 The following command will deploy a Kafka broker with this chart:
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add otterize https://helm.otterize.com
 helm repo update
 helm install --create-namespace -n kafka \
-  -f ${ABSOLUTE_URL}/code-examples/kafka-mtls/helm/values.yaml kafka bitnami/kafka --version 21.4.4
+  -f ${ABSOLUTE_URL}/code-examples/kafka-mtls/helm/values.yaml kafka otterize/bitnami-kafka --version 21.4.4
 ```
 
 You can watch for all pods to be `Ready` using `kubectl get pods -n kafka -w`.


### PR DESCRIPTION
### Description

The Bitnami Helm repository is sometimes down, which causes the related tutorials to fail. We now use a mirror instead.


### References

https://github.com/otterize/helm-charts/pull/274