### PR TITLE
Small touchups to the Azure tutorial

### DIFF
--- a/docs/features/azure-iam/tutorials/azure-iam-aks.mdx
+++ b/docs/features/azure-iam/tutorials/azure-iam-aks.mdx
@@ -114,21 +114,21 @@ az storage account create \
   --resource-group $RESOURCE_GROUP
 ```
 
-Create a source container in the storage account:
+Create an `uploads` container in the storage account:
 ```bash
 az storage container create \
     --account-name $STORAGE_ACCOUNT_NAME \
     --name uploads
 ```
 
-Create a destination container in the storage account:
+Create a `downloads` container in the storage account:
 ```bash
 az storage container create \
     --account-name $STORAGE_ACCOUNT_NAME \
     --name downloads
 ```
 
-Upload a blob to the source container:
+Upload a blob to the `downloads` container:
 ```bash
 echo "Hello, Azure integration" > hello.txt
 az storage blob upload \
@@ -310,7 +310,7 @@ By clicking on the `client` node, you can view and download the full set of Clie
 Use the otterize CLI to download and apply the intents to the cluster:
 
 ```bash
-otterize clientintents export -n otterize-tutorial-azure-iam.<CLUSTER NAME> -v v2 | kubectl apply -f-
+otterize clientintents export -n otterize-tutorial-azure-iam -v v2 | kubectl apply -f-
 ```
 
 Complete ClientIntents file:


### PR DESCRIPTION
### Description
Small touchups to the Azure tutorial:
- Use explicit names for the "uploads" and "downloads" tutorial (instead of source / destination) to eliminate confusion
- Make the `otterize clientintents export` cli easy to copy-paste. 
