### PR TITLE
Update k8s-egress-access-control-tutorial.mdx

### DIFF
--- a/docs/features/network-mapping-network-policies/tutorials/k8s-egress-access-control-tutorial.mdx
+++ b/docs/features/network-mapping-network-policies/tutorials/k8s-egress-access-control-tutorial.mdx
@@ -18,7 +18,8 @@ In this tutorial, we will:
 
 ## Prerequisites
 ### Install Otterize on your cluster
-To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com/), and to integrate your cluster, navigate to the [Integrations page](https://app.otterize.com/integrations) and follow the instructions, but be sure to add the flag below.
+To deploy Otterize, head over to [Otterize Cloud](https://app.otterize.com/), and to integrate your cluster, navigate to the [Integrations page](https://app.otterize.com/integrations) and follow the instructions.
+Make sure that you set enforcement to `true` and add the flag below.
 
 **Note:**  Egress policy creation is off by default. We must add the following flag when installing Otterize to enable egress policy creation.
 


### PR DESCRIPTION
### Description
Clarify in the prerequisite section that Otterize integration need to be set with enforcement mode.
If enforcement is not set, the ingress\egress intents will not affect production env.
