### PR TITLE
Add description for GitHub's auto-merge feature

### DIFF
--- a/docs/features/github/tutorials/automated-pull-requests.mdx
+++ b/docs/features/github/tutorials/automated-pull-requests.mdx
@@ -143,7 +143,9 @@ To add the repository to Otterize Cloud, navigate to the [Integrations page](htt
 5. In the `Open PR on` section, select the `Repository` field, and provide the owner and organization names in the form: *<github user name\>/otterize-tutorial-github*.
 6. Select the `Base Branch` field, and enter *main*.
 7. Select the `ClientIntents path` field, and enter `intents`. It represents the relative path hosting the ClientIntents manifests.
-8. Next, click the `Add` button. This will redirect you to GitHub. If needed, select your GitHub account that owns the tutorial repository and click `continue`. Then, select the desired organization and the tutorial repository (*otterize-tutorial-github*), as depicted in the picture below. Finally, click on `Install`.
+8. You can set the pull request to be auto-merged, using GitHub's merge queue, by enabling the auto merge toggle.
+   Note: for this to work, you have to make sure that you enable `auto-merge` feature in your GitHub repository. For more information about GitHub's auto merge, follow [GitHub's instruction](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository#managing-auto-merge).
+9. Next, click the `Add` button. This will redirect you to GitHub. If needed, select your GitHub account that owns the tutorial repository and click `continue`. Then, select the desired organization and the tutorial repository (*otterize-tutorial-github*), as depicted in the picture below. Finally, click on `Install`.
 
 <img className="tw-w-96 tw-block tw-mx-auto tw-mb-4"
     src="/img/quick-tutorials/github/install-github-app.png"


### PR DESCRIPTION
GitHub's integration now supports GitHub's auto-merge feature for pull requests.
Add a section that describes how to enable this feature when setting up the integration.